### PR TITLE
Fix memcpy-param-overlap

### DIFF
--- a/src/leviosam_utils.cpp
+++ b/src/leviosam_utils.cpp
@@ -219,13 +219,6 @@ void update_cigar(
         memmove(aln->data + cigar_st + n_cigar4,
                 aln->data + cigar_st + fake_bytes,
                 orig_len - (cigar_st + fake_bytes));
-        // If new n_cigar is greater, copy the real CIGAR to the right place.
-        // Skipped this if new n_cigar is smaller than the original value.
-        if (n_cigar4 > fake_bytes){
-            memcpy(aln->data + cigar_st,
-                   aln->data + (n_cigar4 - fake_bytes) + 8,
-                   n_cigar4);
-        }
         aln->core.n_cigar = new_cigar.size();
     }
     for (int i = 0; i < aln->core.n_cigar; i++){


### PR DESCRIPTION
The `memcpy` in the `update_cigar` function was causing `memcpy-param-overlap` errors when turning on ASAN.

As a solution the `memcpy` was safely removed since the function was copying some parts of the `qname` component of data at `aln->data + (n_cigar4 - fake_bytes) + 8` into the block including the `cigar_st` which will be overwritten in a later step.